### PR TITLE
* Check for null before accessing user_tags element

### DIFF
--- a/pmpro-keap.php
+++ b/pmpro-keap.php
@@ -69,6 +69,9 @@ function pmpro_keap_update_keap_contact( $user_id ) {
 		}
 	}
 
+	if (! isset( $options['users_tags'] ) ) {
+		$options['users_tags'] = array();
+	}
 	$new_tags_id = array_values( array_unique( array_merge( $new_tags_id, $options['users_tags'] ) ) );
 
 	// Fetch current tags from Keap for the contact (if needed, depending on the API design).


### PR DESCRIPTION
BUGFIXING: Check for null before accessing users_tag element in the options array.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-keap/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-keap/pulls) for the same update/change?

* Check for null before accessing user_tags element


* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
