### PR TITLE
[BUGFIXING] Keap shouldn't try to update contacts if isn't authorized…

### DIFF
--- a/pmpro-keap.php
+++ b/pmpro-keap.php
@@ -48,8 +48,6 @@ function pmpro_keap_update_keap_contact( $user_id ) {
 	$keap     = PMPro_Keap_Api_Wrapper::get_instance();
 	$response = $keap->pmpro_keap_get_contact_by_email( $user->user_email );
 
-	// We probably need to make sure we can connect and not fatal error.
-
 	// Add the customer to Keap if they don't exist, otherwise update their contact if they do exist.
 	if ( $response['count'] == 0 ) {
 		$response   = $keap->pmpro_keap_add_contact( $user );
@@ -114,6 +112,11 @@ function pmpro_keap_update_keap_contact( $user_id ) {
  * @since 1.0
  */
 function pmpro_keap_user_register( $user_id ) {
+	$keap = PMPro_Keap_Api_Wrapper::get_instance();
+	//Bail if Keap is not authorized. We can't run the update without it.
+	if ( ! $keap->is_keap_api_authorized() ) {
+		return;
+	}
 	pmpro_keap_update_keap_contact( $user_id );
 }
 add_action( 'user_register', 'pmpro_keap_user_register', 10, 1 );
@@ -127,6 +130,11 @@ add_action( 'user_register', 'pmpro_keap_user_register', 10, 1 );
  * @since 1.0
  */
 function pmpro_keap_pmpro_after_change_membership_level( $old_user_levels ) {
+	$keap = PMPro_Keap_Api_Wrapper::get_instance();
+	//Bail if Keap is not authorized. We can't run the update without it.
+	if ( ! $keap->is_keap_api_authorized() ) {
+		return;
+	}
 	// Get unique user IDs from the old user levels.
 	$user_ids = array_unique( array_keys( $old_user_levels ) );
 
@@ -143,6 +151,12 @@ add_action( 'pmpro_after_all_membership_level_changes', 'pmpro_keap_pmpro_after_
  * @since 1.0
  */
 function pmpro_keap_profile_update( $user_id, $old_user_data ) {
+	//Bail if Keap is not authorized.
+	$keap = PMPro_Keap_Api_Wrapper::get_instance();
+	if ( ! $keap->is_keap_api_authorized() ) {
+		return;
+	}
+
 	pmpro_keap_update_keap_contact( $user_id );
 }
 add_action( 'profile_update', 'pmpro_keap_profile_update', 10, 2 );


### PR DESCRIPTION
… in the backend.

 * Create a new API Wrapper function that checks if the is authorized and updates the token stored in options table if makes sense
 * Call this new function before any attempt to update Keap contacts.
 * Add missing error code to error codes array
 * Abstract codes in a constant for readeability purposes

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-keap/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-keap/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added a new function that check the App is properly connected and authorized before attempt to run operations on filted actions like `user_register` or `profile_update` or `pmpro_after_all_membership_level_changes`

Added a missing error to error codes and abstract the array to a constant.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #6 

### How to test the changes in this Pull Request:

1. WIth PMPro and Keap installed and active. 
2. Authorize and then revoke auth from Keap Portal
3. Check log file. Errors shouldn't log anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
